### PR TITLE
fix: disable password authentication

### DIFF
--- a/templates/environment.j2
+++ b/templates/environment.j2
@@ -1,3 +1,3 @@
 BORG_REPO="{{ borgbackup_repository }}"
 BORG_PASSPHRASE="{{ borgbackup_passphrase }}"
-BORG_RSH="ssh -i {{ borgbackup_home }}/config/id_ssh_ed25519 -o UserKnownHostsFile={{ borgbackup_home }}/config/known_hosts -o StrictHostKeyChecking={{ borgbackup_hostkey_checking }} -o ServerAliveInterval={{ borgbackup_ssh_server_alive_interval }} -o ServerAliveCountMax={{ borgbackup_ssh_server_alive_count_max }}"
+BORG_RSH="ssh -i {{ borgbackup_home }}/config/id_ssh_ed25519 -o UserKnownHostsFile={{ borgbackup_home }}/config/known_hosts -o PasswordAuthentication=no -o StrictHostKeyChecking={{ borgbackup_hostkey_checking }} -o ServerAliveInterval={{ borgbackup_ssh_server_alive_interval }} -o ServerAliveCountMax={{ borgbackup_ssh_server_alive_count_max }}"


### PR DESCRIPTION
When the ssh client has no valid ssh key, the client prompts for a password and the process is stuck indefinitely.

This PR makes sure that the password is never asked.